### PR TITLE
feat: upgrade to ink 4.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,14 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "4.0.0-rc", default-features = false }
+ink = { version = "4.2.1", default-features = false }
+
 scale = { package = "parity-scale-codec", version = "3", default-features = false, features = ["derive"] }
-scale-info = { version = "2", default-features = false, features = ["derive"], optional = true }
+scale-info = { version = "2.6", default-features = false, features = ["derive"], optional = true }
+
 
 [lib]
 path = "lib.rs"
-crate-type = [
-    # Used for normal contract Wasm blobs.
-    "cdylib",
-]
 
 [features]
 default = ["std"]

--- a/lib.rs
+++ b/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), no_std, no_main)]
 
 #[ink::contract]
 mod player {

--- a/todo-1.md
+++ b/todo-1.md
@@ -7,14 +7,13 @@
 
 ## Install `cargo-contract`
 
-Be sure to use rust version 1.69.0 
+Be sure to use rust version 1.69.0
 
 ```bash
 rustup component add rust-src
-cargo install --force --locked --version 2.0.0-rc.1 cargo-contract 
+cargo install --force --locked cargo-contract
 ```
-
-If successful you should see an output when executing: `cargo contract --help`.
+When successful you should see an output when executing: `cargo contract --help`. If you are running into trouble installing `cargo-contract`, check the [`cargo-contract` README](https://github.com/paritytech/cargo-contract#readme) for further install instructions.
 
 ## Install `polkadot-js` Browser Extension
 


### PR DESCRIPTION
With the upgrade to the latest ink version it allows to be used with the latest cargo contract version 3.x. instead of the outdated 2.x version.